### PR TITLE
[Fix] Fixed title not beeing centered when content has more than 2 lines

### DIFF
--- a/presentation/screens/Band/elements/BandHeaderContainer.tsx
+++ b/presentation/screens/Band/elements/BandHeaderContainer.tsx
@@ -131,8 +131,10 @@ const BandHeaderContainer = ({
         </ActionContainer>
         <Text
           category="h6"
+          numberOfLines={2}
           style={{
-            fontWeight: 'bold'
+            fontWeight: 'bold',
+            textAlign: 'center'
           }}
         >
           {band.title}

--- a/presentation/screens/Concert/elements/ConcertHeaderContainer.tsx
+++ b/presentation/screens/Concert/elements/ConcertHeaderContainer.tsx
@@ -184,8 +184,10 @@ const ConcertHeaderContainer = ({
         </Text>
         <Text
           category="s1"
+          numberOfLines={2}
           style={{
-            fontWeight: 'bold'
+            fontWeight: 'bold',
+            textAlign: 'center'
           }}
         >
           {concert.title}


### PR DESCRIPTION
# Description

Fixed an issue about the band or concert title not rendering as a centered text.

## Screenshots

* Title fixed 1
![image](https://github.com/Mazurco066/playliter-native/assets/26048377/05e76cb8-c5f6-4e87-a19b-13dbe9ee39fc)

* Title fixed 2
![image](https://github.com/Mazurco066/playliter-native/assets/26048377/eacf9ee9-fe3c-449f-abed-cc74f7cdf866)

## Fixes

* Added orientation to text and locked to 2 max lines.